### PR TITLE
fix: add missing 'fi' to close if statement in GitHub Actions workflow

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -44,6 +44,7 @@ jobs:
           else
             echo "Changes detected."
             echo "changes=true" >> $GITHUB_ENV
+          fi
 
       - name: Commit changes
         if: env.changes == 'true' # Only run if changes are detected


### PR DESCRIPTION
This PR adds the missing 'fi' statement to properly close the if-then-else block in the check for changes step of the GitHub Actions workflow.

- This resolves the syntax error that was causing the workflow to fail.

Closes #9.